### PR TITLE
Add support for more types of modems.

### DIFF
--- a/phone_modem/__init__.py
+++ b/phone_modem/__init__.py
@@ -222,16 +222,15 @@ class PhoneModem:  # pylint: disable=too-many-instance-attributes
             cid_field, cid_data = resp.split("=")
             cid_field = cid_field.strip()
             cid_data = cid_data.strip()
+
             if cid_field == "DATE":
                 self.cid_time = datetime.now()
-                continue
-
-            if cid_field == "NMBR":
+            elif cid_field in ("NMBR", "DDN_NMBR"):
                 self.cid_number = cid_data
-                continue
-
-            if cid_field == "NAME":
+            elif cid_field == "NAME":
                 self.cid_name = cid_data
+
+            if self.cid_number and self.cid_name and self.state == self.STATE_RING:
                 await self._set_state(self.STATE_CALLERID)
                 self.incomingcallnotificationfunc(self.state)
                 _LOGGER.debug(

--- a/phone_modem/__init__.py
+++ b/phone_modem/__init__.py
@@ -230,7 +230,7 @@ class PhoneModem:  # pylint: disable=too-many-instance-attributes
             elif cid_field == "NAME":
                 self.cid_name = cid_data
 
-            if self.cid_number and self.cid_name and self.state == self.STATE_RING:
+            if self.cid_number and self.cid_name and self.state != self.STATE_CALLERID:
                 await self._set_state(self.STATE_CALLERID)
                 self.incomingcallnotificationfunc(self.state)
                 _LOGGER.debug(


### PR DESCRIPTION
- After each line of caller ID data, check whether both a name and
  number field have been received and only then advance to
  STATE_CALLERID.  This allows proper functionality regardless of the
  order in which the caller ID data is sent by the modem.  (closes #3)
- Accept DDN_NMBR as an alias for NMBR in caller ID data.  (closes #2)
